### PR TITLE
chore: remove console.log warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ module.exports = {
     'linebreak-style': [1, 'unix'],
     'no-alert': 2,
     'no-case-declarations': 2,
-    'no-console': 1,
     'no-constant-condition': 2,
     'no-continue': 1,
     'no-div-regex': 2,


### PR DESCRIPTION
This is really not being used nor being useful