### PR TITLE
fix: lint module with its own rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,1 @@
+index.js

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,2 +1,0 @@
----
-extends: standard

--- a/test/validate-config.spec.js
+++ b/test/validate-config.spec.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+'use strict'
 
 const eslint = require('eslint')
 const config = require('../')


### PR DESCRIPTION
Before this change the module was validated with the standardjs
rules only. With this change it is linted also with the additional
rules this module defines.