### PR TITLE
chore: deprecate this module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# eslint-config-aegir
+# DEPRECATED: eslint-config-aegir
+
+This module was deprecated in November 2018. [Aegir is now using ESLint directly](https://github.com/ipfs/aegir/commit/7703051ab40900a67eb43437b3bbb115261e9053), so this module is now longer needed.
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io) [![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/) [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
 [![Dependency Status](https://david-dm.org/ipfs/eslint-config-aegir.svg?style=flat-square)](https://david-dm.org/ipfs/eslint-config-aegir)


### PR DESCRIPTION
[Aegir is now using ESLint directly], so this module is now longer needed.

[Aegir is now using ESLint directly]: https://github.com/ipfs/aegir/commit/7703051ab40900a67eb43437b3bbb115261e9053

Closes #4.

I already deprecated the npm module.

@victorb can you please merge this PR and then do those steps from the deprecating protocol (I don't have enough permissions to do it myself):

> - Add the topic `deprecated` to the repo (pulling this over from #57)
> - Prefix the repo’s description with “DEPRECATED:”
> - Finally, if a repo is dead, archive it (but don’t delete it).
